### PR TITLE
NEW: Setup fortran binary builds on GitHub Actions

### DIFF
--- a/.github/workflows/scons-multi-platform.yml
+++ b/.github/workflows/scons-multi-platform.yml
@@ -41,9 +41,11 @@ jobs:
             shell: powershell
             compilers: m2w64-toolchain
             platform: win
-          # TODO: Cross-compile for Apple Silicon
-          # - os: macos-latest
-          #   arch: arm
+          - os: macos-14
+            shell: bash -el {0}
+            compilers: fortran-compiler c-compiler
+            platform: mac
+            arch: arm
           # TODO: Cross-compile for ARM Linux
           # - os: ubuntu-latest
           #   arch: arm

--- a/.github/workflows/scons-multi-platform.yml
+++ b/.github/workflows/scons-multi-platform.yml
@@ -9,35 +9,87 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      # Set fail-fast to false to ensure that feedback is delivered for all
+      # matrix combinations. Consider changing this to true when your workflow
+      # is stable.
       fail-fast: false
 
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: [3.10]
-        numpy: [1]
-        
+        # TODO: Expand Python targets
+        python: ["3.10"]
+        # TODO: Expand NumPy targets
+        numpy: ["1.26"]
+        arch: ["64"]
+        # Must use special shell options for setup-miniconda action to properly
+        # activate environments
+        include:
+          - os: ubuntu-latest
+            shell: bash -el {0}
+            compilers: fortran-compiler c-compiler
+            platform: linux
+          - os: macos-latest
+            shell: bash -el {0}
+            compilers: fortran-compiler c-compiler
+            platform: mac
+          - os: windows-latest
+            shell: powershell
+            compilers: m2w64-toolchain
+            platform: win
+          # TODO: Cross-compile for Apple Silicon
+          # - os: macos-latest
+          #   arch: arm
+          # TODO: Cross-compile for ARM Linux
+          # - os: ubuntu-latest
+          #   arch: arm
+
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ python }}
-  
-    - name: Add conda to system path
+        activate-environment: GSAS
+        auto-update-conda: false
+        channels: conda-forge
+        python-version: ${{ matrix.python }}
+
+    - name: Remove defaults from channels
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    
+        conda config --remove channels defaults
+
     - name: Install dependencies
-      run: |
-        conda env update --name base fortran-compiler c-compiler scons numpy=${{ numpy }} python=${{ python }} meson pkg-config ninja
+      run: >
+        conda install ${{ matrix.compilers }} scons
+        numpy=${{ matrix.numpy }} python=${{ matrix.python }}
+        meson pkg-config ninja
 
     - name: Build
       run: |
         cd fsource
-        scons
-      
+        scons -Q
+
+    - name: Create archive of binaries on Unix
+      if: matrix.os != 'windows-latest'
+      run: |
+        cd bin
+        ls
+        zip ${{ matrix.platform }}_${{ matrix.arch }}_p${{ matrix.python }}_n${{ matrix.numpy }}.zip *
+
+    - name: Create archive of binaries on Windows
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd bin
+        dir
+        Compress-Archive -Path * -DestinationPath .\${{ matrix.platform }}_${{ matrix.arch }}_p${{ matrix.python }}_n${{ matrix.numpy }}.zip
+
+    # - name: Upload files as artifacts to the release
+    #   uses: softprops/action-gh-release@v0.1.14
+    #   with:
+    #     files: |
+    #       ${{ matrix.platform }}_${{ matrix.arch }}_p${{ matrix.python }}_n${{ matrix.numpy }}.zip
+    #     token: ${{ inputs.token }}

--- a/.github/workflows/scons-multi-platform.yml
+++ b/.github/workflows/scons-multi-platform.yml
@@ -26,6 +26,7 @@ jobs:
         # TODO: Expand NumPy targets
         numpy: ["1.26"]
         arch: ["64"]
+        conda: [""]
         # Must use special shell options for setup-miniconda action to properly
         # activate environments
         include:
@@ -46,6 +47,7 @@ jobs:
             compilers: fortran-compiler c-compiler
             platform: mac
             arch: arm
+            conda: latest
           # TODO: Cross-compile for ARM Linux
           # - os: ubuntu-latest
           #   arch: arm
@@ -59,6 +61,7 @@ jobs:
         auto-update-conda: false
         channels: conda-forge
         python-version: ${{ matrix.python }}
+        miniforge-version: ${{ matrix.conda }}
 
     - name: Remove defaults from channels
       run: |

--- a/.github/workflows/scons-multi-platform.yml
+++ b/.github/workflows/scons-multi-platform.yml
@@ -25,7 +25,6 @@ jobs:
         python: ["3.10"]
         # TODO: Expand NumPy targets
         numpy: ["1.26"]
-        arch: ["64"]
         conda: [""]
         # Must use special shell options for setup-miniconda action to properly
         # activate environments
@@ -34,20 +33,24 @@ jobs:
             shell: bash -el {0}
             compilers: fortran-compiler c-compiler
             platform: linux
+            arch: "64"
           - os: macos-latest
             shell: bash -el {0}
             compilers: fortran-compiler c-compiler
             platform: mac
+            arch: "64"
           - os: windows-latest
             shell: powershell
             compilers: m2w64-toolchain
             platform: win
-          - os: macos-14
-            shell: bash -el {0}
-            compilers: fortran-compiler c-compiler
-            platform: mac
-            arch: arm
-            conda: latest
+            arch: "64"
+          # TODO: Fix scons autodetection of MacOS ARM architecture
+          # - os: macos-14
+          #   shell: bash -el {0}
+          #   compilers: fortran-compiler c-compiler
+          #   platform: mac
+          #   arch: "arm"
+          #   conda: latest
           # TODO: Cross-compile for ARM Linux
           # - os: ubuntu-latest
           #   arch: arm


### PR DESCRIPTION
This PR contains a github actions yaml which builds the fortran binaries for x86 architectures then compresses them into a zip archive.

The last step, which can upload the zip archive to a release as release artifacts is disabled because it requires the trigger for this workflow to be changed to be something like:

```yaml
on:
  push:
    tags:
    # Use pattern matching to only run on version release tags
      - "[0-9]+.[0-9]+.[0-9]+"

  # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:
```

and for the repository to an authorization token added to the secrets which gives the workflow permission to create release pages and add artifacts to them.